### PR TITLE
Remove `memberships` from available scopes

### DIFF
--- a/src/commands/init/prompts/initial.js
+++ b/src/commands/init/prompts/initial.js
@@ -73,9 +73,7 @@ const questions = [
             'read:store-catalog',
             'write:store-catalog',
             'read:store-orders',
-            'write:store-orders',
-            'read:membership',
-            'write:membership'
+            'write:store-orders'
         ],
         when: answers => 'Yes' === answers.has_oauth
     },

--- a/src/utils/validators/schemas/manifest.schema.json
+++ b/src/utils/validators/schemas/manifest.schema.json
@@ -48,9 +48,7 @@
           "read:store-catalog",
           "write:store-catalog",
           "read:store-orders",
-          "write:store-orders",
-          "read:membership",
-          "write:membership"
+          "write:store-orders"
         ],
         "examples": [
           "read:site"


### PR DESCRIPTION
Since the `Membership API` is in a deprecated state, we should remove related permissions from availability.

It was also removed from the related `weebly validate` command schema.