### PR TITLE
Handles `locale` in backwards compatible manner

### DIFF
--- a/src/utils/validators/schemas/manifest.schema.json
+++ b/src/utils/validators/schemas/manifest.schema.json
@@ -58,7 +58,7 @@
       }
     },
     "locale": {
-      "type": ["string", "null"],
+      "type": ["object", "string", "null"],
       "title": "Locale schema",
       "description": "Localization information about this app.",
       "pattern": "^[a-zA-Z]{2}-[a-zA-Z]{2}$",


### PR DESCRIPTION
Now accepts this property's value as an object, string, or null.